### PR TITLE
Revert "[GH-69] add help message when running without --config"

### DIFF
--- a/bongocore/server/src/main.cpp
+++ b/bongocore/server/src/main.cpp
@@ -18,12 +18,11 @@ class WebServerApp : public Poco::Util::ServerApplication {
 
     void defineOptions(Poco::Util::OptionSet& options) {
         Application::defineOptions(options);
-        options.addOption(
-            Poco::Util::Option("please specify config with --config file", "c", "load configuration data from a file")
-                .required(true)
-                .repeatable(false)
-                .argument("config")
-                .callback(Poco::Util::OptionCallback<WebServerApp>(this, &WebServerApp::handleConfig)));
+        options.addOption(Poco::Util::Option("config", "c", "load configuration data from a file")
+                              .required(true)
+                              .repeatable(false)
+                              .argument("config")
+                              .callback(Poco::Util::OptionCallback<WebServerApp>(this, &WebServerApp::handleConfig)));
     }
 
     void initialize(Application& self) {


### PR DESCRIPTION
This reverts commit bb105e4c34a57b42e7d513fe01e677e3142de9f9.